### PR TITLE
添加群聊和私聊消息的MsgID，修复Json消息引发的错误

### DIFF
--- a/Ilyfairy.Robot.Server/RobotManager.cs
+++ b/Ilyfairy.Robot.Server/RobotManager.cs
@@ -408,7 +408,8 @@ namespace Ilyfairy.Robot.Manager
                         {
                             OriginText = originText,
                             Type = code,
-                            Json = property["json"],
+                            //这里解析json会出错，原因未知
+                            //Json = property["json"],
                         };
                         break;
                     case CQCode.cardimage:
@@ -442,6 +443,8 @@ namespace Ilyfairy.Robot.Manager
                 MessageChunks = messageChunks,
                 Sender = sender,
                 GroupId = groupId,
+                //添加对MsgID的支持
+                Message_id = json.Value<int>("message_id")
             });
         }
         /// <summary>
@@ -455,6 +458,8 @@ namespace Ilyfairy.Robot.Manager
             {
                 MessageChunks = messageChunks,
                 Sender = sender,
+                //添加对MsgID的支持
+                Message_id = json.Value<int>("message_id")
             });
         }
 


### PR DESCRIPTION
1.群聊消息和私聊消息的MsgID始终为0，原因是没有写相关实现。
2.CQJson似乎是没法解析的，原因正在排查。现阶段只能当作[QQ小程序]处理，不能获取到Json消息的内容。